### PR TITLE
Added SpellQueueWindow support.

### DIFF
--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -33,6 +33,7 @@ function DruidMacroHelper:Init()
   self:CreateButton('dmhHs', '/dmh cd hs\n/dmh start', 'Disable autoUnshift if not ready to use a healthstone');
   self:CreateButton('dmhSap', '/dmh cd sapper\n/dmh start', 'Disable autoUnshift if not ready to use a sapper');
   self:CreateButton('dmhSuperSap', '/dmh cd supersapper\n/dmh start', 'Disable autoUnshift if not ready to use a super sapper');
+  self.SpellQueueWindow = 400
 end
 
 function DruidMacroHelper:LogOutput(...)
@@ -91,6 +92,12 @@ function DruidMacroHelper:OnSlashStart(parameters)
   self:OnSlashGcd(parameters);
   self:OnSlashMana(parameters);
   self:OnSlashCooldown(parameters);
+
+  if GetCVar("autoUnshift") == 1 then
+    self:LogOutput("Setting SpellQueueWindow to 0")
+    self.SpellQueueWindow = GetCVar("SpellQueueWindow");
+    SetCVar("SpellQueueWindow", 0);
+  end
 end
 
 function DruidMacroHelper:OnSlashStun(parameters)
@@ -127,6 +134,8 @@ function DruidMacroHelper:OnSlashEnd(parameters)
   -- Enable autoUnshift again
   self:LogDebug("Enabling autoUnshift again...");
   SetCVar("autoUnshift", 1);
+  self:LogDebug("Resetting SpellQueueWindow to " .. self.SpellQueueWindow);
+  SetCVar("SpellQueueWindow", self.SpellQueueWindow);
 end
 
 function DruidMacroHelper:OnSlashCooldown(parameters)

--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -24,6 +24,7 @@ function DruidMacroHelper:Init()
   self:RegisterSlashAction('gcd', 'OnSlashGcd', 'Disable autoUnshift if on global cooldown');
   self:RegisterSlashAction('mana', 'OnSlashMana', 'Disable autoUnshift if you are missing mana to shift back into form');
   self:RegisterSlashAction('cd', 'OnSlashCooldown', '|cffffff00<itemId|itemShortcut>[ <itemId|itemShortcut> ...]|r Disable autoUnshift if items are on cooldown, player is stunned, on gcd or out of mana');
+  self:RegisterSlashAction('charge', 'OnSlashCharge', '|cffffff00<unit|target|mouseover|targettarget|arena1 ...>|r Disable autoUnshift if unit is in range of Feral Charge');
   self:RegisterSlashAction('debug', 'OnSlashDebug', '|cffffff00on/off|r Enable or disable debugging output');
   self:CreateButton('dmhStart', '/changeactionbar [noform]1;[form:1]2;[form:3]3;[form:4]4;[form:5]5;6;\n/dmh start', 'Change actionbar based on the current form. (includes /dmh start)');
   self:CreateButton('dmhBar', '/changeactionbar [noform]1;[form:1]2;[form:3]3;[form:4]4;[form:5]5;6;', 'Change actionbar based on the current form. (without /dmh start)');
@@ -146,6 +147,24 @@ function DruidMacroHelper:OnSlashCooldown(parameters)
       self:LogDebug("Item on cooldown: ", itemNameOrId);
       prevent = true;
     end
+  end
+  if prevent then
+    SetCVar("autoUnshift", 0);
+  end
+end
+
+function DruidMacroHelper:OnSlashCharge(unit)
+  if ~UnitExists(unit) then
+    self:LogOutput("Unit not found:", unit);
+    return;
+  end
+  local prevent = false;
+  if ~IsSpellInRange(L["SPELL_CHARGE"], unit) then
+    prevent = true
+  end
+  local start, duration = GetSpellCooldown(L["SPELL_CHARGE"]);
+  if duration > 0 then
+    prevent = true
   end
   if prevent then
     SetCVar("autoUnshift", 0);

--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -154,6 +154,9 @@ function DruidMacroHelper:OnSlashCooldown(parameters)
 end
 
 function DruidMacroHelper:OnSlashCharge(unit)
+  if unit == nil then
+    unit = "target"
+  end
   if ~UnitExists(unit) then
     self:LogOutput("Unit not found:", unit);
     return;

--- a/Locale/deDE.lua
+++ b/Locale/deDE.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "deDE" then return end
 L["FORM_DIRE_BEAR"] = "Terrorbärengestalt"
 L["FORM_CAT"] = "Katzengestalt"
 L["FORM_TRAVEL"] = "Reisegestalt"
+L["SPELL_CHARGE"] = "Wilde Attacke"

--- a/Locale/enUS.lua
+++ b/Locale/enUS.lua
@@ -4,3 +4,4 @@ local _, L = ...;
 L["FORM_DIRE_BEAR"] = "Dire Bear Form"
 L["FORM_CAT"] = "Cat Form"
 L["FORM_TRAVEL"] = "Travel Form"
+L["SPELL_CHARGE"] = "Feral Charge"

--- a/Locale/esES.lua
+++ b/Locale/esES.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "esES" then return end
 L["FORM_DIRE_BEAR"] = "Forma de oso nefasto"
 L["FORM_CAT"] = "Forma felina"
 L["FORM_TRAVEL"] = "Forma de viaje"
+L["SPELL_CHARGE"] = "Carga feral"

--- a/Locale/frFR.lua
+++ b/Locale/frFR.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "frFR" then return end
 L["FORM_DIRE_BEAR"] = "Forme d’ours redoutable"
 L["FORM_CAT"] = "Forme de félin"
 L["FORM_TRAVEL"] = "Forme de voyage"
+L["SPELL_CHARGE"] = "Charge farouche"

--- a/Locale/itIT.lua
+++ b/Locale/itIT.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "itIT" then return end
 L["FORM_DIRE_BEAR"] = "Dire Bear Form"
 L["FORM_CAT"] = "Cat Form"
 L["FORM_TRAVEL"] = "Travel Form"
+L["SPELL_CHARGE"] = "Feral Charge"

--- a/Locale/koKR.lua
+++ b/Locale/koKR.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "koKR" then return end
 L["FORM_DIRE_BEAR"] = "광포한 곰 변신"
 L["FORM_CAT"] = "표범 변신"
 L["FORM_TRAVEL"] = "치타 변신"
+L["SPELL_CHARGE"] = "야성의 돌진"

--- a/Locale/ptBR.lua
+++ b/Locale/ptBR.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "ptBR" then return end
 L["FORM_DIRE_BEAR"] = "Forma de Urso Hediondo"
 L["FORM_CAT"] = "Forma de Felino"
 L["FORM_TRAVEL"] = "Forma de Viagem"
+L["SPELL_CHARGE"] = "Investida Feral"

--- a/Locale/ruRU.lua
+++ b/Locale/ruRU.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "ruRU" then return end
 L["FORM_DIRE_BEAR"] = "Облик лютого медведя"
 L["FORM_CAT"] = "Облик кошки"
 L["FORM_TRAVEL"] = "Походный облик"
+L["SPELL_CHARGE"] = "Звериная атака"

--- a/Locale/zhCN.lua
+++ b/Locale/zhCN.lua
@@ -5,3 +5,4 @@ if GetLocale() ~= "zhCN" then return end
 L["FORM_DIRE_BEAR"] = "巨熊形态"
 L["FORM_CAT"] = "猎豹形态"
 L["FORM_TRAVEL"] = "旅行形态"
+L["SPELL_CHARGE"] = "野性冲锋"

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ https://www.curseforge.com/wow/addons/druidmacrohelper
 /click dmhEnd
 ```
 
+### Feral Charge
+#### Go to Bear and Feral Charge from any form. Checks if we are in range and Feral Charge is off CD.
+```lua
+#showtooltip
+/dmh charge
+/use [noform:1] Dire Bear Form
+/cast Feral Charge
+/dmh end
+```
+
+```
+
 ## Available commands
 
 There are two options on how to use the addon in macros:
@@ -114,6 +126,9 @@ The slash commands allow for more flexibility in some cases (like custom itemIds
 * `/dmh cd <itemId|itemShortcut>[ <itemId|itemShortcut> ...]`
 
     Disable autoUnshift if items are on cooldown, player is stunned, on gcd or out of mana
+* `/dmh charge <unit|target|mouseover|arena1 ...>`
+
+    Disable autoUnshift if specified unit is out of range of Feral Charge
 
 ### Item shortcuts
 For checking cooldowns you can use item shortcuts instead of the id. Available are:

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ https://www.curseforge.com/wow/addons/druidmacrohelper
 /dmh end
 ```
 
-```
-
 ## Available commands
 
 There are two options on how to use the addon in macros:


### PR DESCRIPTION
People have been playing with SpellQueueWindow = 0 to further remove delays from their shifts, but it would probably be ideal to have a small window. Read more on how it works here http://thedefiantguild.com/forums/discussion/15431.html

I have made some simple logic for setting it to 0 when we want to powershift and then reset it to what it was initially (400ms default) after we are done shifting.

Posted a dev build of the addon on the Druid Discord about 2 weeks ago. About 4-5 ppl said they would test it, and have not heard about any issues. You can find the discussion here https://discord.com/channels/253205420225724416/923726689610108958/923733175472123934 (Archived thread in #tbc-feral-tank)