### PR TITLE
Fix for IsCurrentSpell Maul Queueing. Requires SpellID

### DIFF
--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -135,7 +135,7 @@ function DruidMacroHelper:OnSlashGcd(parameters)
 end
 
 function DruidMacroHelper:OnSlashMaul(parameters)
-  if (IsCurrentSpell("Maul") and IsSpellInRange("Bash", "target") == 1) then
+  if (IsCurrentSpell(GetSpellLink("Maul")[2]) and IsSpellInRange("Bash", "target") == 1) then
     self:LogDebug("You have Maul queued");
     SetCVar("autoUnshift", 0);
   end


### PR DESCRIPTION
https://wowpedia.fandom.com/wiki/API_IsCurrentSpell  requires SpellID
Updated to get Maul Spell from SpellBook using GetSpellLink. 
 https://warcraft.wiki.gg/wiki/API_GetSpellLink

