### PR TITLE
Summon snake through creature id

### DIFF
--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -159,7 +159,7 @@ end
 
 function DruidMacroHelper:SnakeHelper(parameters)
   for i=1,GetNumCompanions("CRITTER") do
-    if select(2, GetCompanionInfo("CRITTER", i)) == "Albino Snake" then
+    if select(1, GetCompanionInfo("CRITTER", i)) == 7561 then
         CallCompanion("CRITTER", i)
 
         if (#(parameters) < 1) then


### PR DESCRIPTION
Instead of summoning the snake by checking against the name, "Albino Snake", now summon through Creature ID.
This solves locale issues where the snake has a different name.