### PR TITLE
Albino Snake default functionality fix + unlearned pet warning

### DIFF
--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -175,6 +175,8 @@ function DruidMacroHelper:SnakeHelper(parameters)
 
         return
     end
+    self:LogOutput("This character has not learned the Albino Snake pet.")
+    self:LogOutput("Please purchase the Albino Snake from Breanni in Dalaran. You must learn this pet on this character.")
   end
 end
 

--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -153,9 +153,9 @@ function DruidMacroHelper:SnakeHelper(parameters)
         C_Timer.After(2, function() DismissCompanion("CRITTER") end)
         return
     end
-    self:LogOutput("This character has not learned the Albino Snake pet.")
-    self:LogOutput("Please purchase the Albino Snake from Breanni in Dalaran. You must learn this pet on this character.")
   end
+  self:LogOutput("This character has not learned the Albino Snake pet.")
+  self:LogOutput("Please purchase the Albino Snake from Breanni in Dalaran. You must learn this pet on this character.")
 end
 
 function DruidMacroHelper:OnSlashSnake(parameters)

--- a/DruidMacroHelper.lua
+++ b/DruidMacroHelper.lua
@@ -40,7 +40,6 @@ function DruidMacroHelper:OnEnable()
   self:CreateButton('dmhHs', '/dmh cd hs\n/dmh start', 'Disable autoUnshift if not ready to use a healthstone');
   self:CreateButton('dmhSap', '/dmh cd sapper\n/dmh start', 'Disable autoUnshift if not ready to use a sapper');
   self:CreateButton('dmhSuperSap', '/dmh cd supersapper\n/dmh start', 'Disable autoUnshift if not ready to use a super sapper');
-  self:RegisterEvent("UPDATE_SHAPESHIFT_FORM")
   self.ChatThrottle = nil
   self.SpellQueueWindow = 400
   self.AutoUnsnake = false
@@ -147,32 +146,11 @@ function DruidMacroHelper:OnSlashMaul(parameters)
   end
 end
 
-function DruidMacroHelper:UPDATE_SHAPESHIFT_FORM(event)
-  C_Timer.After(0.1, function() 
-    if self.AutoUnsnake and GetShapeshiftForm() ~= 3 then
-      self:LogDebug("Auto unsnaked")
-      DismissCompanion("CRITTER")
-      self.AutoUnsnake = false
-    end
-  end)
-end
-
 function DruidMacroHelper:SnakeHelper(parameters)
   for i=1,GetNumCompanions("CRITTER") do
     if select(1, GetCompanionInfo("CRITTER", i)) == 7561 then
         CallCompanion("CRITTER", i)
-
-        if (#(parameters) < 1) then
-          self.AutoUnsnake = true
-        else
-          local additional = tremove(parameters, 1);
-          if additional == "timed" then
-            C_Timer.After(2, function() DismissCompanion("CRITTER") end)
-          elseif additional == "auto" then
-            self.AutoUnsnake = true
-          end
-        end
-
+        C_Timer.After(2, function() DismissCompanion("CRITTER") end)
         return
     end
     self:LogOutput("This character has not learned the Albino Snake pet.")

--- a/DruidMacroHelper.toc
+++ b/DruidMacroHelper.toc
@@ -1,8 +1,8 @@
-## Interface: 90207
-## Interface-Classic: 11403
+## Interface: 110007
+## Interface-Classic: 11506
 ## Interface-BCC: 20504
 ## Interface-Wrath: 30400
-## Interface-Cata: 40400
+## Interface-Cata: 40401
 ## Title: DruidMacroHelper
 ## Version: 1.3.1
 ## Author: Mylaerla-Everlook


### PR DESCRIPTION
This PR fixes an issue where the default command `/dmh snake` does not always dismissing the pet when it should. 
This is caused by UPDATE_SHAPESHIFT_FORM being called multiple times now in Cataclysm Classic.
The default functionality of dismissing the pet is now always called 2 seconds after it was summoned. This method is more stable and works consistently.

This PR also adds a warning if the character does not have the Albino Pet summoned.